### PR TITLE
✨ ignore merge commits, add range checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   # use specific versions in case something breaks
   - pip install tox-travis==0.11 tox==3.7.0
 
 script:
-  # run tox with automatically derived number of parallel jobs
-  - tox --parallel auto
+  # run tox
+  - tox
+
+  # use this version of py-commit-checker to check itself, in emoji mode!
+  - pip install -e . &&
+    PY_COMMIT_CHECKER_ARGS='--emojis' py-commit-checker-branch origin/master

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg?style=for-the-badg
 
 A basic git commit message format checker.
 
+_Note: check out https://github.com/jorisroovers/gitlint for a much better,
+more featureful, and actually tested implementation! the only unique feature in
+`py-commit-checker` is the built in leading emoji check... 😀_
+
 # Checkers
 
 Small set of mandatory (cannot be disabled) and optional (opt in or out) checkers.
@@ -43,7 +47,7 @@ pip install py-commit-checker
 # Usage
 
 ```bash
-# check for 50/72 + emoji compliance on HEAD
+# check top commit for 50/72 + emoji compliance on HEAD
 py-commit-checker --emojis
 
 # check a specific commit
@@ -51,6 +55,10 @@ py-commit-checker --emojis --commit HEAD~2
 
 # check a repo at a path other than cwd
 py-commit-checker --repo-path ../openbsd
+
+# check a range of commits; py-commit-checker-branch helper script (installed
+# alongside py-commit-checker)
+PY_COMMIT_CHECKER_ARGS='--emojis' py-commit-checker-branch origin/master
 ```
 
 # Why is this not just a single regex

--- a/py-commit-checker-branch
+++ b/py-commit-checker-branch
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Small script used to run py-commit-checker against all commits in a branch vs
+# a merge-base (eg for pull request checking). Set options in
+# PY_COMMIT_CHECKER_ARGS
+
+set -e
+
+REF_BASE=${1:-origin/master}
+
+for sha in $(git rev-list HEAD..."$REF_BASE"); do
+    echo "Checking $sha ..."
+    py-commit-checker $PY_COMMIT_CHECKER_ARGS --commit "$sha"
+done

--- a/py_commit_checker/__version__.py
+++ b/py_commit_checker/__version__.py
@@ -1,0 +1,5 @@
+"""
+Version file, used by the module and setup.py.
+"""
+
+__version__ = "0.3.0"

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,26 @@
 Setup package.
 """
 import io
-import os
+
 from setuptools import setup
 
 # Get long description from readme
 with io.open("README.md", "rt", encoding="utf8") as readmefile:
-    readme = readmefile.read()
+    README = readmefile.read()
+
+
+def get_version():
+    """Get version spec from module"""
+    from py_commit_checker.__version__ import (  # pylint: disable=bad-option-value,import-outside-toplevel
+        __version__,
+    )
+
+    return __version__
+
 
 setup(
     name="py-commit-checker",
-    version="0.2.1",
+    version=get_version(),
     description="Basic commit checker, with optional emoji check",
     author="Noah Pendleton",
     author_email="2538614+noahp@users.noreply.github.com",
@@ -21,7 +31,7 @@ setup(
         "Code": "https://github.com/noahp/py-commit-checker",
         "Issue tracker": "https://github.com/noahp/py-commit-checker/issues",
     },
-    long_description=readme,
+    long_description=README,
     long_description_content_type="text/markdown",
     license="MIT",
     packages=["py_commit_checker"],
@@ -32,10 +42,12 @@ setup(
             "py-commit-checker=py_commit_checker.py_commit_checker:main"
         ]
     },
+    scripts=["py-commit-checker-branch"],
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -10,27 +10,26 @@
 requires = [ "setuptools == 40.6.3", "wheel == 0.32.3"]
 
 [tox]
-envlist = py27, py36, black
+envlist = py27, py36, py37, py38, black
 
 [testenv]
 deps =
     py27: pylint==1.9.4
-    py36: pylint==2.3.0
+    py36,py37,py38: pylint==2.4.3
 whitelist_externals =
     /bin/bash
 commands =
     # super simple test time.
-    # pylint
-    bash -c "pylint ./**/*.py"
+    # pylint; use bash extglob to get the files we want to check
+    bash -c "pylint ./*.py ./**/*.py"
+
     # confirm we can build the wheel with no errors
-    {envpython} setup.py bdist_wheel
-    # test installation
-    bash -c "pip install dist/*.whl"
+    {envpython} setup.py bdist_wheel --bdist-dir {envdir}/bdist --dist-dir {envdir}/dist
+    bash -c "pip install -U {envdir}/dist/*.whl"
+
     # very basic runtime check
     py-commit-checker --help
 
-    # also validate the top commit :D
-    py-commit-checker --emojis
 
 [testenv:black]
 deps=


### PR DESCRIPTION
- ignore merge commits. Fixes #7.
- add helper script for checking a range of commits
- tidy up tox/travis
- add py3.7/3.8 support